### PR TITLE
Fix A* search

### DIFF
--- a/src/lib/algorithms/graph/astar.ts
+++ b/src/lib/algorithms/graph/astar.ts
@@ -20,12 +20,11 @@ export const aStar = (grid: GridType, startTile: TileType, endTile: TileType) =>
 
   while (untraversedTiles.length > 0) {
     untraversedTiles.sort((a, b) => {
-      if (functionCost[a.row][a.col] < functionCost[b.row][b.col]) {
-        return (
-          (a.row - endTile.row) ** 2 +
-          (a.col - endTile.col) ** 2 -
-          ((b.row - endTile.row) ** 2 + (b.col - endTile.col) ** 2)
-        );
+      if (functionCost[a.row][a.col] == functionCost[b.row][b.col]) {
+        // In a tie, choose the path which has made the most progress
+        // so far, i.e. the one with the shortest heuristic distance
+        // remaining.
+        return b.distance - a.distance;
       }
       return functionCost[a.row][a.col] - functionCost[b.row][b.col];
     });

--- a/src/lib/algorithms/graph/astar.ts
+++ b/src/lib/algorithms/graph/astar.ts
@@ -20,7 +20,7 @@ export const aStar = (grid: GridType, startTile: TileType, endTile: TileType) =>
 
   while (untraversedTiles.length > 0) {
     untraversedTiles.sort((a, b) => {
-      if (functionCost[a.row][a.col] == functionCost[b.row][b.col]) {
+      if (functionCost[a.row][a.col] === functionCost[b.row][b.col]) {
         // In a tie, choose the path which has made the most progress
         // so far, i.e. the one with the shortest heuristic distance
         // remaining.


### PR DESCRIPTION
Congrats on getting to the top of HN.

I noticed that A* search didn't look right, especially when running on an empty grid. I think I found the bug.

The sort function for untraversed tiles appeared to contain a tiebreaker clause, but due to a typo, the tiebreaker was applied when `costA < costB` rather than `costA == costB`, i.e. it was basically applied randomly to everything except actual ties.

Additionally, the tiebreaker was choosing the closest euclidean distance. This seemed inconsistent with the heuristic function, which is based on manhattan distance. In addition to the inconsistency, it felt wrong to be computing distance anywhere other than in the heuristic function. I adjusted the code to choose the node with the greater "distance traveled so far". Since this is only used in a tie scenario, this is equivalent to taking the shorter heuristic distance (since the function cost is the sum of the two). I think this achieves what the tiebreaker was intended to do, but using the actual heuristic function rather than an alternative distance measurement.

With these changes, the A* search now correctly searches one single optimal path on the empty maze, and seems to do better on the Recursive Division mazes.

(The bug did not harm performance on Binary Tree mazes, where there is always one correct solution that involves only going down or right, never up or left.)